### PR TITLE
Gofetcher uses dual stack in dialer. It is added because the ipv4 addres...

### DIFF
--- a/gofetcher/gofetcher.go
+++ b/gofetcher/gofetcher.go
@@ -89,6 +89,7 @@ func NewGofetcher() *Gofetcher {
 		Dial: (&net.Dialer{
 			Timeout:   30 * time.Second,
 			KeepAlive: KeepAliveTimeout * time.Second,
+			DualStack: true,
 		}).Dial,
 		TLSHandshakeTimeout: 10 * time.Second,
 	}


### PR DESCRIPTION
...s from dns record and only iy is used by default. If something is broken with ipv4, there will be no attempt to connect to ipv6